### PR TITLE
Fix wrong DAMAGE_PITFALL and DAMAGE_DEVIL descriptions

### DIFF
--- a/group__enums.html
+++ b/group__enums.html
@@ -4726,9 +4726,9 @@ Enumerations</h2></td></tr>
 </td></tr>
 <tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca1fd9f2d48998b0eb519f4aef9e26784e"></a>DAMAGE_POOP&#160;</td><td class="fielddoc"><p>damage from red poop </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca62cf902c707d3c6e4c4d128610348845"></a>DAMAGE_DEVIL&#160;</td><td class="fielddoc"><p>damage comes from devil room deal </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca62cf902c707d3c6e4c4d128610348845"></a>DAMAGE_DEVIL&#160;</td><td class="fielddoc"><p> </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca02369e68e3333e33c832c31096a4f8d2"></a>DAMAGE_ISSAC_HEART&#160;</td><td class="fielddoc"><p>Indicates the damage has been redirected from <a class="el" href="namespace_isaac.html">Isaac</a>'s Heart familiar </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca02369e68e3333e33c832c31096a4f8d2"></a>DAMAGE_ISSAC_HEART&#160;</td><td class="fielddoc"><p>indicates the damage has been redirected from <a class="el" href="namespace_isaac.html">Isaac</a>'s Heart familiar </p>
 </td></tr>
 <tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcae1579720f2a132ee967e9a1c664699a4"></a>DAMAGE_TNT&#160;</td><td class="fielddoc"><p>damage comes from a TNT barrel </p>
 </td></tr>
@@ -4744,7 +4744,7 @@ Enumerations</h2></td></tr>
 </td></tr>
 <tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca5207b8d5cb8f8590e70b1a12fca30267"></a>DAMAGE_IV_BAG&#160;</td><td class="fielddoc"><p>damage from using the IV Bag </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca2dbd114bef9f0dcd318beb0ca89b24bd"></a>DAMAGE_PITFALL&#160;</td><td class="fielddoc"><p>damage comes from the passage of time (used for player damage by time limited special seeds) </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca2dbd114bef9f0dcd318beb0ca89b24bd"></a>DAMAGE_PITFALL&#160;</td><td class="fielddoc"><p>damage comes from pitfalls (such as ones spawned by Little Horn) </p>
 </td></tr>
 <tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca458d86d89f807062e25b1f1a07250d4f"></a>DAMAGE_CHEST&#160;</td><td class="fielddoc"><p>damage comes from spiked chest </p>
 </td></tr>

--- a/group__enums.html
+++ b/group__enums.html
@@ -4706,51 +4706,51 @@ Enumerations</h2></td></tr>
       </table>
 </div><div class="memdoc">
 <table class="fieldtable">
-<tr><th colspan="2">Enumerator</th></tr><tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca66eecb26b7962c2557b1c79663adfb73"></a>DAMAGE_NOKILL&#160;</td><td class="fielddoc"><p>damage can not kill the receiver </p>
+<tr><th colspan="2">Enumerator</th></tr><tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca66eecb26b7962c2557b1c79663adfb73"></a>DAMAGE_NOKILL&#160;</td><td class="fielddoc"><p>Damage can not kill the receiver </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcac50b14cf6946cd1d0767f4601733fca8"></a>DAMAGE_FIRE&#160;</td><td class="fielddoc"><p>source is some sort of fire (ie. fireplace) </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcac50b14cf6946cd1d0767f4601733fca8"></a>DAMAGE_FIRE&#160;</td><td class="fielddoc"><p>Source is some sort of fire (ie. fireplace) </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca1e6f9b19c2410feb65deb948d4847af0"></a>DAMAGE_EXPLOSION&#160;</td><td class="fielddoc"><p>damage comes from an explosion </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca1e6f9b19c2410feb65deb948d4847af0"></a>DAMAGE_EXPLOSION&#160;</td><td class="fielddoc"><p>Damage comes from an explosion </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca77ad97d7a79eccab3175de705dfe6609"></a>DAMAGE_LASER&#160;</td><td class="fielddoc"><p>damage comes from laser </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca77ad97d7a79eccab3175de705dfe6609"></a>DAMAGE_LASER&#160;</td><td class="fielddoc"><p>Damage comes from laser </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca0b27ddbbf4c1c2c5901215f00a54ef87"></a>DAMAGE_ACID&#160;</td><td class="fielddoc"><p>damage comes from acid, e.g. blood acid </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca0b27ddbbf4c1c2c5901215f00a54ef87"></a>DAMAGE_ACID&#160;</td><td class="fielddoc"><p>Damage comes from acid, e.g. blood acid </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca3762de68cc75498c1e7e1607daa70881"></a>DAMAGE_RED_HEARTS&#160;</td><td class="fielddoc"><p>damage affects only red hearts if &gt; 1 (ex: razor) </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca3762de68cc75498c1e7e1607daa70881"></a>DAMAGE_RED_HEARTS&#160;</td><td class="fielddoc"><p>Damage affects only red hearts if &gt; 1 (ex: razor) </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca5b771a8233c901f2d0952da639963424"></a>DAMAGE_COUNTDOWN&#160;</td><td class="fielddoc"><p>damage from unicorn horn, the nail, game kid that has cooldown </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca5b771a8233c901f2d0952da639963424"></a>DAMAGE_COUNTDOWN&#160;</td><td class="fielddoc"><p>Damage from unicorn horn, the nail, game kid that has cooldown </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca795b21cd72be569f90ca744b0b296866"></a>DAMAGE_SPIKES&#160;</td><td class="fielddoc"><p>damage from spikes </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca795b21cd72be569f90ca744b0b296866"></a>DAMAGE_SPIKES&#160;</td><td class="fielddoc"><p>Damage from spikes </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca773ccdd6be6a31a43a13d7c787413d4d"></a>DAMAGE_CLONES&#160;</td><td class="fielddoc"><p>damage is done by clones when they took damage, avoid infinite loops </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca773ccdd6be6a31a43a13d7c787413d4d"></a>DAMAGE_CLONES&#160;</td><td class="fielddoc"><p>Damage is done by clones when they took damage, avoid infinite loops </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca1fd9f2d48998b0eb519f4aef9e26784e"></a>DAMAGE_POOP&#160;</td><td class="fielddoc"><p>damage from red poop </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca1fd9f2d48998b0eb519f4aef9e26784e"></a>DAMAGE_POOP&#160;</td><td class="fielddoc"><p>Damage from red poop </p>
 </td></tr>
 <tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca62cf902c707d3c6e4c4d128610348845"></a>DAMAGE_DEVIL&#160;</td><td class="fielddoc"><p> </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca02369e68e3333e33c832c31096a4f8d2"></a>DAMAGE_ISSAC_HEART&#160;</td><td class="fielddoc"><p>indicates the damage has been redirected from <a class="el" href="namespace_isaac.html">Isaac</a>'s Heart familiar </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca02369e68e3333e33c832c31096a4f8d2"></a>DAMAGE_ISSAC_HEART&#160;</td><td class="fielddoc"><p>Indicates the damage has been redirected from <a class="el" href="namespace_isaac.html">Isaac</a>'s Heart familiar </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcae1579720f2a132ee967e9a1c664699a4"></a>DAMAGE_TNT&#160;</td><td class="fielddoc"><p>damage comes from a TNT barrel </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcae1579720f2a132ee967e9a1c664699a4"></a>DAMAGE_TNT&#160;</td><td class="fielddoc"><p>Damage comes from a TNT barrel </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca9c1ff0eff455d0ad6700950f2697fa1d"></a>DAMAGE_INVINCIBLE&#160;</td><td class="fielddoc"><p>damages even if invincible (currently only for player). Used on IV Bag. </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca9c1ff0eff455d0ad6700950f2697fa1d"></a>DAMAGE_INVINCIBLE&#160;</td><td class="fielddoc"><p>Damages even if invincible (currently only for player). Used on IV Bag. </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcaf04615a5af149b5f028e8cf5f5c40782"></a>DAMAGE_SPAWN_FLY&#160;</td><td class="fielddoc"><p>creates a fly when damage is applied </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcaf04615a5af149b5f028e8cf5f5c40782"></a>DAMAGE_SPAWN_FLY&#160;</td><td class="fielddoc"><p>Creates a fly when damage is applied </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca649542ca100ce20ef31884c74d77a5fe"></a>DAMAGE_POISON_BURN&#160;</td><td class="fielddoc"><p>damage comes from POISON/BURN flags </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca649542ca100ce20ef31884c74d77a5fe"></a>DAMAGE_POISON_BURN&#160;</td><td class="fielddoc"><p>Damage comes from POISON/BURN flags </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca19a73d37dea65a119295f78fadba3146"></a>DAMAGE_CURSED_DOOR&#160;</td><td class="fielddoc"><p>damage comes from a cursed door </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca19a73d37dea65a119295f78fadba3146"></a>DAMAGE_CURSED_DOOR&#160;</td><td class="fielddoc"><p>Damage comes from a cursed door </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcab13be7e68f4cc4e8e60ef7ef22720ccf"></a>DAMAGE_TIMER&#160;</td><td class="fielddoc"><p>damage comes from the passage of time (used for player damage by time limited special seeds) </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcab13be7e68f4cc4e8e60ef7ef22720ccf"></a>DAMAGE_TIMER&#160;</td><td class="fielddoc"><p>Damage comes from the passage of time (used for player damage by time limited special seeds) </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca5207b8d5cb8f8590e70b1a12fca30267"></a>DAMAGE_IV_BAG&#160;</td><td class="fielddoc"><p>damage from using the IV Bag </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca5207b8d5cb8f8590e70b1a12fca30267"></a>DAMAGE_IV_BAG&#160;</td><td class="fielddoc"><p>Damage from using the IV Bag </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca2dbd114bef9f0dcd318beb0ca89b24bd"></a>DAMAGE_PITFALL&#160;</td><td class="fielddoc"><p>damage comes from pitfalls (such as ones spawned by Little Horn) </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca2dbd114bef9f0dcd318beb0ca89b24bd"></a>DAMAGE_PITFALL&#160;</td><td class="fielddoc"><p>Damage comes from pitfalls (such as ones spawned by Little Horn) </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca458d86d89f807062e25b1f1a07250d4f"></a>DAMAGE_CHEST&#160;</td><td class="fielddoc"><p>damage comes from spiked chest </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca458d86d89f807062e25b1f1a07250d4f"></a>DAMAGE_CHEST&#160;</td><td class="fielddoc"><p>Damage comes from spiked chest </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca3f2fa6e97cb840c00d08ea67de6aab38"></a>DAMAGE_FAKE&#160;</td><td class="fielddoc"><p>fake damage that should trigger player's damage effects. </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fca3f2fa6e97cb840c00d08ea67de6aab38"></a>DAMAGE_FAKE&#160;</td><td class="fielddoc"><p>Fake damage that should trigger player's damage effects. </p>
 </td></tr>
-<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcab48f1747dcfffa183e1187ac7e43dae0"></a>DAMAGE_BOOGER&#160;</td><td class="fielddoc"><p>damage from booger tear </p>
+<tr><td class="fieldname"><a id="ggab084d3a6d6ddd144ea6df4af965f93fcab48f1747dcfffa183e1187ac7e43dae0"></a>DAMAGE_BOOGER&#160;</td><td class="fielddoc"><p>Damage from booger tear </p>
 </td></tr>
 </table>
 


### PR DESCRIPTION
DAMAGE_PITFALL description was duplicated from DAMAGE_TIMER.
DAMAGE_DEVIL is not called when getting items from the devil deal; I didn't manage to find out when it is actually used.