### PR TITLE
Fix descriptions for player stats

### DIFF
--- a/class_entity_player.html
+++ b/class_entity_player.html
@@ -713,27 +713,27 @@ Public Attributes</h2></td></tr>
 <tr class="memdesc:a994e4d64cb627e8c29da1f8b41d55116"><td class="mdescLeft">&#160;</td><td class="mdescRight">How long until the player can spawn their next tear?  <a href="#a994e4d64cb627e8c29da1f8b41d55116">More...</a><br /></td></tr>
 <tr class="separator:a994e4d64cb627e8c29da1f8b41d55116"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:aab893842a6dd2de9fb7cb5ecf0e26952"><td class="memItemLeft" align="right" valign="top">integer&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#aab893842a6dd2de9fb7cb5ecf0e26952">MaxFireDelay</a></td></tr>
-<tr class="memdesc:aab893842a6dd2de9fb7cb5ecf0e26952"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How long between each tear can spawn?  <a href="#aab893842a6dd2de9fb7cb5ecf0e26952">More...</a><br /></td></tr>
+<tr class="memdesc:aab893842a6dd2de9fb7cb5ecf0e26952"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Tears Stat.</b> <!--End Custom comment --> How long between each tear can spawn?  <a href="#aab893842a6dd2de9fb7cb5ecf0e26952">More...</a><br /></td></tr>
 <tr class="separator:aab893842a6dd2de9fb7cb5ecf0e26952"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:aa251b5962fdc050ad450ea379ea20c06"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#aa251b5962fdc050ad450ea379ea20c06">ShotSpeed</a></td></tr>
-<tr class="memdesc:aa251b5962fdc050ad450ea379ea20c06"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast does the tear travel when spawned?  <a href="#aa251b5962fdc050ad450ea379ea20c06">More...</a><br /></td></tr>
+<tr class="memdesc:aa251b5962fdc050ad450ea379ea20c06"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the ShotSpeed Stat.</b> <!--End Custom comment --> How fast does the tear travel when spawned?  <a href="#aa251b5962fdc050ad450ea379ea20c06">More...</a><br /></td></tr>
 <tr class="separator:aa251b5962fdc050ad450ea379ea20c06"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:aec088e0dc34fdebbff613fae521a681c"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#aec088e0dc34fdebbff613fae521a681c">Damage</a></td></tr>
-<tr class="memdesc:aec088e0dc34fdebbff613fae521a681c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How much damage do the players tears or other main weapons do?  <a href="#aec088e0dc34fdebbff613fae521a681c">More...</a><br /></td></tr>
+<tr class="memdesc:aec088e0dc34fdebbff613fae521a681c"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Damage Stat.</b> <!--End Custom comment --> How much damage do the players tears or other main weapons do?  <a href="#aec088e0dc34fdebbff613fae521a681c">More...</a><br /></td></tr>
 <tr class="separator:aec088e0dc34fdebbff613fae521a681c"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a5e06c433bdbaa90ea7f790feada291e4"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a5e06c433bdbaa90ea7f790feada291e4">TearHeight</a></td></tr>
-<tr class="memdesc:a5e06c433bdbaa90ea7f790feada291e4"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How high above the ground is the tear when it spawns? Affects range.  <a href="#a5e06c433bdbaa90ea7f790feada291e4">More...</a><br /></td></tr>
+<tr class="memdesc:a5e06c433bdbaa90ea7f790feada291e4"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Range Stat * -1.</b> <!--End Custom comment --> How high above the ground is the tear when it spawns?  <a href="#a5e06c433bdbaa90ea7f790feada291e4">More...</a><br /></td></tr>
 <tr class="separator:a5e06c433bdbaa90ea7f790feada291e4"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a3a533321b560d86a49522fe7a3e0d011"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a3a533321b560d86a49522fe7a3e0d011">TearFallingSpeed</a></td></tr>
-<tr class="memdesc:a3a533321b560d86a49522fe7a3e0d011"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE.<!--start Custom comment --> <b>This is equal to the Range Stat. </b> <!--End Custom comment -->How fast is the tear moving up or down when it spawns? Affects range.  <a href="#a3a533321b560d86a49522fe7a3e0d011">More...</a><br /></td></tr>
+<tr class="memdesc:a3a533321b560d86a49522fe7a3e0d011"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast is the tear moving up or down when it spawns? Affects range.  <a href="#a3a533321b560d86a49522fe7a3e0d011">More...</a><br /></td></tr>
 <tr class="separator:a3a533321b560d86a49522fe7a3e0d011"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a9e7f6b7aea91810091b2e59b7a939c32"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a9e7f6b7aea91810091b2e59b7a939c32">TearFallingAcceleration</a></td></tr>
 <tr class="separator:a9e7f6b7aea91810091b2e59b7a939c32"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a754dc33235da0b63f2e67046eb0e8316"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a754dc33235da0b63f2e67046eb0e8316">MoveSpeed</a></td></tr>
-<tr class="memdesc:a754dc33235da0b63f2e67046eb0e8316"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast can the player move?  <a href="#a754dc33235da0b63f2e67046eb0e8316">More...</a><br /></td></tr>
+<tr class="memdesc:a754dc33235da0b63f2e67046eb0e8316"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Speed Stat.</b> <!--End Custom comment --> How fast can the player move?  <a href="#a754dc33235da0b63f2e67046eb0e8316">More...</a><br /></td></tr>
 <tr class="separator:a754dc33235da0b63f2e67046eb0e8316"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a1c5b44f2f2e16fa343d045827403b97e"><td class="memItemLeft" align="right" valign="top">integer&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a1c5b44f2f2e16fa343d045827403b97e">TearFlags</a></td></tr>
-<tr class="memdesc:a1c5b44f2f2e16fa343d045827403b97e"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How much gravity does the tear have to start? Affects range.  <a href="#a1c5b44f2f2e16fa343d045827403b97e">More...</a><br /></td></tr>
+<tr class="memdesc:a1c5b44f2f2e16fa343d045827403b97e"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. Various <a href="group__enums.html#ga497749198295d1f3d5ecd1c6d5ea2cce">tear flags</a>  <a href="#a1c5b44f2f2e16fa343d045827403b97e">More...</a><br /></td></tr>
 <tr class="separator:a1c5b44f2f2e16fa343d045827403b97e"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a59614016fc2cc6ceba3a970ed154f722"><td class="memItemLeft" align="right" valign="top"><a class="el" href="class_color.html">Color</a>&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a59614016fc2cc6ceba3a970ed154f722">TearColor</a></td></tr>
 <tr class="separator:a59614016fc2cc6ceba3a970ed154f722"><td class="memSeparator" colspan="2">&#160;</td></tr>
@@ -743,7 +743,7 @@ Public Attributes</h2></td></tr>
 <tr class="memdesc:a90b8f0fd5b85c8aa1e629ed1e901184d"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. Can the player fly over rocks and pits?  <a href="#a90b8f0fd5b85c8aa1e629ed1e901184d">More...</a><br /></td></tr>
 <tr class="separator:a90b8f0fd5b85c8aa1e629ed1e901184d"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a3e8019f2af95ebe0725ce9a667c03d79"><td class="memItemLeft" align="right" valign="top">float&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a3e8019f2af95ebe0725ce9a667c03d79">Luck</a></td></tr>
-<tr class="memdesc:a3e8019f2af95ebe0725ce9a667c03d79"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. Better luck generally means better random events.  <a href="#a3e8019f2af95ebe0725ce9a667c03d79">More...</a><br /></td></tr>
+<tr class="memdesc:a3e8019f2af95ebe0725ce9a667c03d79"><td class="mdescLeft">&#160;</td><td class="mdescRight">Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Luck Stat.</b> <!--End Custom comment --> Better luck generally means better random events.  <a href="#a3e8019f2af95ebe0725ce9a667c03d79">More...</a><br /></td></tr>
 <tr class="separator:a3e8019f2af95ebe0725ce9a667c03d79"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a8e6418eba83417914dc252363894916a"><td class="memItemLeft" align="right" valign="top"><a class="el" href="group__enums.html#gad65102fdce2fc7b437b3d73d7753e747">BabySubType</a>&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="class_entity_player.html#a8e6418eba83417914dc252363894916a">BabySkin</a></td></tr>
 <tr class="separator:a8e6418eba83417914dc252363894916a"><td class="memSeparator" colspan="2">&#160;</td></tr>
@@ -5205,7 +5205,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How much damage do the players tears or other main weapons do? </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Damage Stat.</b> <!--End Custom comment --> How much damage do the players tears or other main weapons do? </p>
 
 </div>
 </div>
@@ -5295,7 +5295,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. Better luck generally means better random events. </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Luck Stat.</b> <!--End Custom comment --> Better luck generally means better random events. </p>
 
 </div>
 </div>
@@ -5311,7 +5311,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How long between each tear can spawn? </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Tears Stat.</b> <!--End Custom comment --> How long between each tear can spawn? </p>
 
 </div>
 </div>
@@ -5327,7 +5327,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast can the player move? </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Speed Stat.</b> <!--End Custom comment --> How fast can the player move? </p>
 
 </div>
 </div>
@@ -5372,7 +5372,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast does the tear travel when spawned? </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the ShotSpeed Stat.</b> <!--End Custom comment --> How fast does the tear travel when spawned? </p>
 
 </div>
 </div>
@@ -5430,7 +5430,7 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE.<!--start Custom comment --> <b>This is equal to the Range stat. </b> <!--End Custom comment --> How fast is the tear moving up or down when it spawns? Affects range. </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How fast is the tear moving up or down when it spawns? Affects range. </p>
 
 </div>
 </div>
@@ -5446,7 +5446,17 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How much gravity does the tear have to start? Affects range. </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. Various <a href="group__enums.html#ga497749198295d1f3d5ecd1c6d5ea2cce">tear flags</a>. </p>
+
+<div class="example_code">
+This code makes Isaac's tears spectral. 
+<pre><code class="language-lua">local mod:OnEvaluateTearFlags(player, flag)
+    player.TearFlags = player.TearFlags | TearFlags.TEAR_SPECTRAL
+end
+
+mod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, mod.OnEvaluateTearFlags, CacheFlag.CACHE_TEARFLAG)
+</code></pre> 
+</div>
 
 </div>
 </div>
@@ -5462,7 +5472,18 @@ Get the number of Pickup items you can carry. (1 on default. 2 with belly button
       </table>
 </div><div class="memdoc">
 
-<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How high above the ground is the tear when it spawns? Affects range. </p>
+<p>Player stat - Only change this in a callback to MC_EVALUATE_CACHE. <!--start Custom comment --> <b>This is equal to the Range Stat * -1.</b> <!--End Custom comment --> How high above the ground is the tear when it spawns? </p>
+
+<div class="example_code">
+This code gives Isaac a +5 range up.
+<pre><code class="language-lua">local mod:OnEvaluateRange(player, flag)
+    -- we give -5 because the TearHeight stat is always negative; the lower the number - the further the tear travels
+    player.TearHeight = player.TearHeight - 5
+end
+
+mod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, mod.OnEvaluateRange, CacheFlag.CACHE_RANGE)
+</code></pre> 
+</div>
 
 </div>
 </div>


### PR DESCRIPTION
It was stated that `TearFallingAcceleration` is equal to the range stat which is not true.
Added **bold** comments where the attribute is equal to a player stat.