### PR TITLE
Fix misinformation in GetActiveSubCharge

### DIFF
--- a/class_entity_player.html
+++ b/class_entity_player.html
@@ -2573,7 +2573,7 @@ Public Attributes</h2></td></tr>
 </div><div class="memdoc">
 
 <!--start Custom comment -->
-<p>Get the current charge progress of the second charge of your current active item. This bar is only active, when you have the Collectible "9Volt"</p>
+<p>Get the current charge progress of the second charge of your current active item. This bar is only active, when you have the Collectible "The Battery"</p>
 <!--End Custom comment -->
 </div>
 </div>


### PR DESCRIPTION
"9 Volt" does not use this, "The Battery" does. All 9 Volt does is adding one extra charge after item is used (one charge items do not use subcharge as well)