### PR TITLE
Described VarData in EntityPlayer:AddCollectible

### DIFF
--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -84,10 +84,34 @@ ___
 [ ](#){: .rep .tooltip .badge }
 #### void AddCollectible ( [CollectibleType](../enums/CollectibleType) Type, int Charge, boolean AddConsumables, int ActiveSlot, int VarData ) {: .copyable aria-label='Functions' }
 
-Slot 0 is default (normal active item)
-Slot 1 is used by Schoolbag
-Slot 2 is used for pocket active items
-Please note that slot 2 cannot be used if character did not start with a pocket active
+Slot 0 is default (normal active item)  
+Slot 1 is used by Schoolbag  
+Slot 2 is used for pocket active items  
+
+???- note "Notes"
+	Slot 2 cannot be used if character did not start with a pocket active
+
+VarData is used for the storage of a persistent context-sensitive value
+
+???- note "Notes"
+	This is a list of all items that make use of VarData:  
+	- Jar of Wisps: Wisps spawned on next use (Max 12)  
+	- D Infinity, Blank Card, Clear Rune, Placebo: Current maximum charge (Any value above 0)  
+	- Hold: Stored poop  
+	> Poop Types:  
+	> [0] None  
+	> [1] Normal  
+	> [2] Flies  
+	> [3] Fire  
+	> [4] Petrified  
+	> [5] Toxic  
+	> [6] Black  
+	> [7] Holy  
+	> [8] X-Lax  
+	> [9] Fart  
+	> [10] Bomb  
+	> [11] Explosive Diarrhea  
+	> [12+] Empty  
 
 ___ 
 ### Add·Controls·Cooldown () {: aria-label='Functions' }


### PR DESCRIPTION
Updated the description of EntityPlayer:AddCollectible to explain what VarData is for and a few cases where it is used in the game