### PR TITLE
fixing link

### DIFF
--- a/docs/ItemConfig.md
+++ b/docs/ItemConfig.md
@@ -52,7 +52,7 @@ Returns the Itemobject of a given CollectibleID.
 ___ 
 ### Get·Collectibles () {: aria-label='Functions' }
 [ ](#){: .const .tooltip .badge } [ ](#){: .abrep .tooltip .badge }
-#### const [ItemList](../CppContainer_Vector_ItemConfigList) GetCollectibles ( ) {: .copyable aria-label='Functions' }
+#### const [userdata] GetCollectibles ( ) {: .copyable aria-label='Functions' }
 
 Returns the List of all Collectibles. 
 


### PR DESCRIPTION
since Get() is bugged, no-one should ever be using this for any reason.

by changing the data type here, it makes that more explicit.