### PR TITLE
fix typo "explossion"

### DIFF
--- a/docs/Room.md
+++ b/docs/Room.md
@@ -441,9 +441,9 @@ ___
 #### void KeepDoorsClosed ( ) {: .copyable aria-label='Functions' }
 
 ___ 
-### Mama·Mega·Explossion () {: aria-label='Functions' }
+### Mama·Mega·Explosion () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void MamaMegaExplossion ( ) {: .copyable aria-label='Functions' }
+#### void MamaMegaExplosion ( ) {: .copyable aria-label='Functions' }
 
 ___ 
 ### Play·Music () {: aria-label='Functions' }

--- a/docs/Room.md
+++ b/docs/Room.md
@@ -443,7 +443,7 @@ ___
 ___ 
 ### Mama·Mega·Explosion () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void MamaMegaExplosion ( ) {: .copyable aria-label='Functions' }
+#### void MamaMegaExplosion ( [Vector](Vector.md) Position ) {: .copyable aria-label='Functions' }
 
 ___ 
 ### Play·Music () {: aria-label='Functions' }


### PR DESCRIPTION
Calling `room:MamaMegaExplossion()` doesn't work, but `room:MamaMegaExplosion()` does.