### PR TITLE
Update Sprite.md

### DIFF
--- a/docs/Sprite.md
+++ b/docs/Sprite.md
@@ -85,7 +85,7 @@ Returns the currently rendered Frame of the Overlay of the given Sprite. It acts
 ___
 ### Get·Texel () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### [Color](Color.md) GetTexel ( [Vector](Vector.md) SamplePos, [Vector](Vector.md) RenderPos, float AlphaThreshold, int LayerID = 0 ) {: .copyable aria-label='Functions' }
+#### [KColor](KColor.md) GetTexel ( [Vector](Vector.md) SamplePos, [Vector](Vector.md) RenderPos, float AlphaThreshold, int LayerID = 0 ) {: .copyable aria-label='Functions' }
 Returns the color of the pixel of the Sprite at the given sample position. RenderPos can be neglected and set to a null vector
 ___
 ### Is·Event·Triggered () {: aria-label='Functions' }


### PR DESCRIPTION
Hello,

The docs state that calling GetTexel on a Sprite returns a Color object. However, in my testing GetTexel appears to return a KColor object instead. Here's a brief example in Lua that illustrates this:
```
local mod = RegisterMod('GetTexel Example', 1)
local sprite = Sprite()
local color = sprite:GetTexel(Vector(0, 0), Vector(0, 0), 1)

-- Treating color as a Color object, prints "nil nil nil"
print(tostring(color.R) .. " " .. tostring(color.G) .. " " .. tostring(color.B))

-- Treating color as a KColor object, prints "0.0 0.0 0.0"
print(tostring(color.Red) .. " " .. tostring(color.Green) .. " " .. tostring(color.Blue))
```

Thanks!

 