### PR TITLE
Update EntityLaser.md

### DIFF
--- a/docs/EntityLaser.md
+++ b/docs/EntityLaser.md
@@ -46,6 +46,15 @@ ___
 [ ](#){: .abrep .tooltip .badge }
 #### boolean IsCircleLaser ( ) {: .copyable aria-label='Functions' }
 
+???- note "Note"
+  This function cannot differentiate between different types of Circle Laser, however these may be identified by their SubType:
+  
+	* 0 - Linear Laser (Typical laser with a start and end point)
+  * 1 - Ring Ludovico (Controlled laser ring for Ludo synergies)
+  * 2 - Ring Projectile (Tech X)
+  * 3 - Ring Follow Parent (Maw of the Void)
+  * 4 - No Impact (No impact splash, e.g. Tech Zero)
+ 
 ___
 ### Is·Sample·Laser () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }


### PR DESCRIPTION
add a note to EntityLaser:IsCircleLaser() explaining how to differentiate circle lasers using the LaserSubType enumeration currently missing from the API