### PR TITLE
Update Room:CheckLine() note

### DIFF
--- a/docs/Room.md
+++ b/docs/Room.md
@@ -24,7 +24,7 @@ Returns 2 values:
 
     **0** : makes the line check collide with anything that impedes ground movement
 
-    **1** : is a cheaper version of 0, but is not as reliable
+    **1** : is a cheaper version of 0, but is not as reliable (For example, can return true if line of sight can be gained between diagonally adjacent rocks)
 
     **2** : is used for explosions, it only collides with walls and indestructible blocks
 


### PR DESCRIPTION
Provides an example of why you may not want to use LinecheckMode 1 over its more expensive counterpart