### PR TITLE
Added note to Mass attribute

### DIFF
--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -697,7 +697,8 @@ ___
 ### Mass {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }
 #### float Mass  {: .copyable aria-label='Variables' }
-
+???+ note "Notes"
+    Stationary enemies have a Mass of 100. This does not apply to some stationary non-enemies, like slots.
 ___
 ### Max·Hit·Points {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }


### PR DESCRIPTION
I've recently discovered stationary enemies consistently have a mass of 100. Since I cannot find any other reliable way of detecting when an enemy is stationary, it was suggested that I include this so other people may use such a method.