### PR TITLE
Fixed example code in animation functions

### DIFF
--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -390,21 +390,23 @@ ___
 [ ](#){: .abrep .tooltip .badge }
 #### void AnimateHappy ( ) {: .copyable aria-label='Functions' }
 Plays the happy animation, played when taking a positive pill.
-	???- example "Example Code"
-		Plays the happy animation.
-		``local player = Isaac.GetPlayer()
-		player:AnimateHappy()
-		``
+
+???- example "Example Code"
+	Plays the happy animation.
+	```local player = Isaac.GetPlayer()
+	player:AnimateHappy()
+	```
 ___
 ### Animate·Light·Travel () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
 #### void AnimateLightTravel ( ) {: .copyable aria-label='Functions' }
 Plays the animation that is played when entering the light in the ascent, or entering the cathedral.
-	??- example "Example Code"
-		Plays the animation.
-		``local player = Isaac.GetPlayer()
-		player:AnimateLightTravel()
-		``
+
+???- example "Example Code"
+	Plays the animation.
+	```local player = Isaac.GetPlayer()
+	player:AnimateLightTravel()
+	```
 
 ___
 ### Animate·Pickup () {: aria-label='Functions' }
@@ -433,11 +435,12 @@ ___
 [ ](#){: .abrep .tooltip .badge }
 #### void AnimateSad ( ) {: .copyable aria-label='Functions' }
 Plays the sad animation, played when taking a negative pill.
-	???- example "Example Code"
-		Plays the sad animation.
-		``local player = Isaac.GetPlayer()
-		player:AnimateSad()
-		``
+
+???- example "Example Code"
+	Plays the sad animation.
+	```local player = Isaac.GetPlayer()
+	player:AnimateSad()
+	```
 ___
 ### Animate·Teleport () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }

--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -392,11 +392,12 @@ ___
 Plays the happy animation, played when taking a positive pill.
 
 ???- example "Example Code"
-	Plays the happy animation.
-	```local player = Isaac.GetPlayer()
-	player:AnimateHappy()
-	```
-___
+    This code plays the happy animation.
+    ```lua 
+    local player = Isaac.GetPlayer()
+    player:AnimateHappy()
+    ```
+
 ### Animate·Light·Travel () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
 #### void AnimateLightTravel ( ) {: .copyable aria-label='Functions' }
@@ -404,7 +405,8 @@ Plays the animation that is played when entering the light in the ascent, or ent
 
 ???- example "Example Code"
 	Plays the animation.
-	```local player = Isaac.GetPlayer()
+	```lua 
+    local player = Isaac.GetPlayer()
 	player:AnimateLightTravel()
 	```
 
@@ -438,7 +440,8 @@ Plays the sad animation, played when taking a negative pill.
 
 ???- example "Example Code"
 	Plays the sad animation.
-	```local player = Isaac.GetPlayer()
+	```lua 
+    	local player = Isaac.GetPlayer()
 	player:AnimateSad()
 	```
 ___


### PR DESCRIPTION
When I made the descriptions and example code for animation functions, it didn't display correctly. This should fix that issue.