### PR TITLE
Removed info from Game:StartRoomTransition()

### DIFF
--- a/docs/Game.md
+++ b/docs/Game.md
@@ -503,45 +503,6 @@ Note that if you use `RoomTransitionAnim.PIXELATION` (2), you must not interrupt
 		* 2: Death Certificate dimension
 
 ???- note "Notes"
-	-RoomTransitionAnim.WALK: Will play the correct walk animation regardless of the direction you use, as long as the direction is in the same axis as the room you're traveling too. So if the room is on the left, it'll play the correct animation whether you use Direction.LEFT or Direction.RIGHT. If you put in the wrong direction, it'll just fade to the next room (not fade to black, just fade). If you put in Direction.NO_DIRECTION it'll play a fade to black regardless.
-	
-	-RoomTransitionAnim.FADE: Will play a fade to black regardless of the direction. If the direction is Direction.NO_DIRECTION the fade will be shorter.
-	
-	-RoomTransitionAnim.PIXELATION: Will play the usual pixelation regardless of the direction.
-
-	-RoomTransitionAnim.TELEPORT: Will play the teleport animation and sound, then it'll play the walk animation using the direction you inputted. If Direction.NO_DIRECTION is used, it'll play a short fade to white instead of the walk animation.
-
-	-RoomTransitionAnim.MAZE: Like RoomTransitionAnim.WALK but better, as it will always play the walk animation you put into it. Using Direction.NO_DIRECTION will play a short fade to black.
-
-	-RoomTransitionAnim.ANKH: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.DEAD_CAT: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.ONE_UP: Works like RoomTransitionAnim.MAZE but plays the one up sound upon entering the room.
-
-	-RoomTransitionAnim.COLLAR: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.JUDAS_SHADOW: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.LAZARUS: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.WOMB_TELEPORT: Makes the player invisible and plays a fade to black. If used to change into the same room, the player's visibility won't be restored. If Direction.NO_DIRECTION is used, it'll play a shorter fade to black.
-
-	-RoomTransitionAnim.GLOWING_HOURGLASS: Basically the same as using the glowing hourglass item, further testing should be done to see if there are any differences. Ignores the direction and the room index inputted.
-	
-	-RoomTransitionAnim.MISSING_POSTER: Works like RoomTransitionAnim.MAZE.
-
-	-RoomTransitionAnim.BOSS_FORCED: Plays a walk animation twice. If used with Direction.NO_DIRECTION plays a short fade to black. Doesnt even skip the boss vs screen.
-	
-	-RoomTransitionAnim.PORTAL_TELEPORT: Works like RoomTransitionAnim.WOMB_TELEPORT.
-
-	-RoomTransitionAnim.FORGOTTEN_TELEPORT: Works like RoomTransitionAnim.FADE.
-
-	-RoomTransitionAnim.FADE_MIRROR: Plays the mirror exit sound and a fade to white animation. If used with Direction.NO_DIRECTION, the fade to white is shorter.
-	
-	-RoomTransitionAnim.MINECART: Works like RoomTransitionAnim.FADE.
-
-	-RoomTransitionAnim.DEATH_CERTIFICATE: The player lies down, then there's a fade to black and the player appears lying down again and gets up. Ignores the direction, but using Direction.NO_DIRECTION will make the fade shorter. The game is paused during the lying down and getting up animation.
 
 	The boss vs screen overrides all of these transitions, however, using RoomTransitionAnim.DEATH_CERTIFICATE will make it so the player appears lying down after the vs screen and the game will be paused while they get up.
 


### PR DESCRIPTION
Removed the extra info about the RoomTransitionEnum from the Game:StartRoomTransition() notes, as now it is in the actual enum.