### PR TITLE
dofile/loadfile are no longer available

### DIFF
--- a/docs/tutorials/Standard-Library.md
+++ b/docs/tutorials/Standard-Library.md
@@ -10,14 +10,12 @@ Lua provides a standard library. However, since Isaac is a sandboxed environment
 | -------------------- | ------------------------------------
 | json (with `require("json")`) | socket (with `require("socket")`)
 | assert                        | debug
-| collectgarbage                | io
-| coroutine                     | os
-| dofile                        | package
-| error                         | require *(unmodified)*
-| getmetatable
-| ipairs
-| load
-| loadfile
+| collectgarbage                | dofile
+| coroutine                     | io
+| error                         | loadfile
+| getmetatable                  | os
+| ipairs                        | package
+| load                          | require *(unmodified)*
 | math
 | next
 | pairs


### PR DESCRIPTION
The latest version of main.lua is removing them.

```
if not _LUADEBUG then
	debug = nil
	arg = nil
	dofile = nil
	loadfile = nil
end
```