### PR TITLE
Changes to Game:StartStageTransition() & Level:SetStage()

### DIFF
--- a/docs/Game.md
+++ b/docs/Game.md
@@ -556,13 +556,6 @@ ___
 
 Starts a transition animation, like the ones used when entering a trapdoor or light beam to reach the next stage.
 
-
-**Stage Transition types:**
-
-* 0: Standard transition. Removes the playermodel before the pixel fadeout. Then plays the Stage Nightmare animation. The player starts in fetal position after the transition.
-* 1: Standard transition with pixel fadein/out, nightmare cutscene but the player model doesnt get removed and starts in the normal standing position after the transition.
-* &gt;2: Same as 0
-
 ???+ bug "Bug"
 	Contrary to previous beliefs, this function will crash when **not** provided with an EntityPlayer. It is worth noting however, that the function, even when used correctly, is inconsistent and seems to sometimes crash for no reason.
 ___

--- a/docs/Game.md
+++ b/docs/Game.md
@@ -556,6 +556,8 @@ ___
 
 Starts a transition animation, like the ones used when entering a trapdoor or light beam to reach the next stage.
 
+The value of Animation seemingly has no actual effect on the transition. (If you have more info, submit a pull request.)
+
 ???+ bug "Bug"
 	Contrary to previous beliefs, this function will crash when **not** provided with an EntityPlayer. It is worth noting however, that the function, even when used correctly, is inconsistent and seems to sometimes crash for no reason.
 ___

--- a/docs/Game.md
+++ b/docs/Game.md
@@ -562,7 +562,7 @@ Starts a transition animation like it`s playing when entering a trapdoor to swit
 * &gt;2: Same as 0
 
 ???+ bug "Bug"
-    Not defining a player will crash the game. To prevent this, either pass an EntityPlayer from elsewhere, such as a callback, or use [`Isaac.GetPlayer()`](Isaac.md#getplayer): `Game():StartStageTransition(false, 0, Isaac.GetPlayer())`
+    Not defining a player will crash the game. To prevent this, either pass an EntityPlayer from elsewhere, such as a callback, or use [`Isaac.GetPlayer()`](Isaac.md#getplayer): `Game():StartStageTransition(false, 0, Isaac.GetPlayer())`. It is worth noting that this function is still inconsistent, and is known to crash for seemingly no reason.
 ___
 ### Update () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }

--- a/docs/Game.md
+++ b/docs/Game.md
@@ -562,7 +562,7 @@ Starts a transition animation like it`s playing when entering a trapdoor to swit
 * &gt;2: Same as 0
 
 ???+ bug "Bug"
-    Not defining a player will crash the game. To prevent this, either pass an EntityPlayer from elsewhere, such as a callback, or use [`Isaac.GetPlayer()`](Isaac.md#getplayer): `Game():StartStageTransition(false, 0, Isaac.GetPlayer())`. It is worth noting that this function is still inconsistent, and is known to crash for seemingly no reason.
+	Contrary to previous beliefs, this function will crash when **not** provided with an EntityPlayer. It is worth noting however, that the function, even when used correctly, is inconsistent and seems to sometimes crash for no reason.
 ___
 ### Update () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }

--- a/docs/Game.md
+++ b/docs/Game.md
@@ -554,7 +554,9 @@ ___
 [ ](#){: .abrep .tooltip .badge }
 #### void StartStageTransition ( boolean SameStage, StageTransition::Animation Animation, [EntityPlayer](EntityPlayer.md) Player ) {: .copyable aria-label='Functions' }
 
-Starts a transition animation like it`s playing when entering a trapdoor to switch between stages.
+Starts a transition animation, like the ones used when entering a trapdoor or light beam to reach the next stage.
+
+
 **Stage Transition types:**
 
 * 0: Standard transition. Removes the playermodel before the pixel fadeout. Then plays the Stage Nightmare animation. The player starts in fetal position after the transition.

--- a/docs/Game.md
+++ b/docs/Game.md
@@ -562,7 +562,7 @@ Starts a transition animation like it`s playing when entering a trapdoor to swit
 * &gt;2: Same as 0
 
 ???+ bug "Bug"
-    Defining a player will crash the game. To prevent this, keep player-argument nil: `Game():StartStageTransition(false, 0, nil)`
+    Not defining a player will crash the game. To prevent this, either pass an EntityPlayer from elsewhere, such as a callback, or use [`Isaac.GetPlayer()`](Isaac.md#getplayer): `Game():StartStageTransition(false, 0, Isaac.GetPlayer())`
 ___
 ### Update () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -374,7 +374,7 @@ StageOffset acts as the new "floor":
 * 2 would be equally difficult to Basement II,
 * 3 would be equally difficult to Caves I
 
-StageTypeOffset tells the game what "stage" to use, based on the listed IDs in stages.xml, however, the default stage of the floor's ID will be added on top of this
+StageTypeOffset tells the game what "stage" to use, based on the listed IDs in [stages.xml](xml/stages.md), however, the default stage of the floor's ID will be added on top of this
 
 * StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
 * StageOffset = 2 means the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -370,11 +370,12 @@ for SetStage/SetNextStage to have effect, call Init afterward
 
 StageOffset acts as the new "floor"
 e.g. 1 would be equally difficult to Basement I, 
-     2 would be equally difficult to Basement II
- and 3 would be equally difficult to Caves I
+     2 would be equally difficult to Basement II,
+     3 would be equally difficult to Caves I
 
 StageTypeOffset tells the game what "stage" to use, based on the listed IDs in stages.xml, however, the default stage of the floor's ID will be added on top of this
 e.g. StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
+     StageOffset = 2 means the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
      StageOffset = 3 means the stage at ID 4(Caves' stage ID) + StageTypeOffset
 If you wish to directly use a stage ID, you can subtract the default stage for any given floor using a function like:
 ```lua

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -377,9 +377,9 @@ StageOffset acts as the new "floor":
 
 StageTypeOffset tells the game what "stage" to use, based on the listed IDs in [stages.xml](xml/stages.md), however, the default stage of the floor's ID will be added on top of this
 
-* StageOffset = 1 uses the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
-* StageOffset = 2 uses the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
-* StageOffset = 3 uses the stage at ID 4(Caves' stage ID) + StageTypeOffset
+* StageOffset = 1 uses the stage at ID: StageTypeOffset + 1(Basement's stage ID), 
+* StageOffset = 2 uses the stage at ID: StageTypeOffset + 1(Same as StageOffset 1),
+* StageOffset = 3 uses the stage at ID: StageTypeOffset + 4(Caves' stage ID)
 
 If you wish to directly use a stage ID, you can subtract the default stage for any given floor using a function like:
 ```lua

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -368,7 +368,32 @@ ___
 #### void SetStage ( int StageOffset, int StageTypeOffset ) {: .copyable aria-label='Functions' }
 for SetStage/SetNextStage to have effect, call Init afterward
 
-Not much is known about these functions; submit a pull request if you learn more.
+StageOffset acts as the new "floor"
+e.g. 1 would be equally difficult to Basement I, 
+     2 would be equally difficult to Basement II
+ and 3 would be equally difficult to Caves I
+
+StageTypeOffset tells the game what "stage" to use, based on the listed IDs in stages.xml, however, the default stage of the floor's ID will be added on top of this
+e.g. StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
+     StageOffset = 3 means the stage at ID 4(Caves' stage ID) + StageTypeOffset
+If you wish to directly use a stage ID, you can subtract the default stage for any given floor using a function like:
+```lua
+local function defaultStageOfFloor(StageOffset)
+	if (StageOffset == 0) then
+		print("Attempting to get default stage of floor 0. This is not recommended")
+		Isaac.DebugString("Attempting to get default stage of floor 0. This is not recommended")
+		return 0
+	elseif (StageOffset <= 8) then
+		return math.ceil(StageOffset/2) * 3 -2
+	else
+		return 10 + (StageOffset-8) * 2
+	end
+end
+```
+
+If you pass StageOffset = 0, the function acts (seemingly) arbitrarily, though it is still possible to use
+StageOffset = -1 has an unusually small floor
+StageOffsets 9, 12, and 13 are all seemingly hardcoded in some ways. Blue Womb seems to have it's backdrop and layout forced, while The Void and Home seems to force their name and backdrop
 
 ___
 ### Set·State·Flag () {: aria-label='Functions' }

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -368,15 +368,18 @@ ___
 #### void SetStage ( int StageOffset, int StageTypeOffset ) {: .copyable aria-label='Functions' }
 for SetStage/SetNextStage to have effect, call Init afterward
 
-StageOffset acts as the new "floor"
-e.g. 1 would be equally difficult to Basement I, 
-     2 would be equally difficult to Basement II,
-     3 would be equally difficult to Caves I
+StageOffset acts as the new "floor":
+
+* 1 would be equally difficult to Basement I, 
+* 2 would be equally difficult to Basement II,
+* 3 would be equally difficult to Caves I
 
 StageTypeOffset tells the game what "stage" to use, based on the listed IDs in stages.xml, however, the default stage of the floor's ID will be added on top of this
-e.g. StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
-     StageOffset = 2 means the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
-     StageOffset = 3 means the stage at ID 4(Caves' stage ID) + StageTypeOffset
+
+* StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
+* StageOffset = 2 means the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
+* StageOffset = 3 means the stage at ID 4(Caves' stage ID) + StageTypeOffset
+
 If you wish to directly use a stage ID, you can subtract the default stage for any given floor using a function like:
 ```lua
 local function defaultStageOfFloor(StageOffset)
@@ -391,10 +394,12 @@ local function defaultStageOfFloor(StageOffset)
 	end
 end
 ```
+???- note "Notes"
+	If you pass StageOffset = 0, the function acts (seemingly) arbitrarily, though it is still possible to use
 
-If you pass StageOffset = 0, the function acts (seemingly) arbitrarily, though it is still possible to use
-StageOffset = -1 has an unusually small floor
-StageOffsets 9, 12, and 13 are all seemingly hardcoded in some ways. Blue Womb seems to have it's backdrop and layout forced, while The Void and Home seems to force their name and backdrop
+	StageOffset = -1 has an unusually small floor
+
+	StageOffsets 9, 12, and 13 are all seemingly hardcoded in some ways. Blue Womb seems to have it's backdrop and layout forced, while The Void and Home seems to force their name and backdrop
 
 ___
 ### Set·State·Flag () {: aria-label='Functions' }

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -356,7 +356,7 @@ ___
 [ ](#){: .abrep .tooltip .badge }
 #### void SetNextStage ( ) {: .copyable aria-label='Functions' }
 
-This function puts you in the next stage without applying any of the floor changes. You are meant to call the `Game.StartStageTransition` method after using this function.
+This function puts you in the next stage without applying any of the floor changes. For the changes to fully apply, either use the `reseed` [console command](tutorials/DebugConsole.md#reseed), or [Game.StartStageTransition](Game.md#startstagetransition).
 ___
 ### Set·Red·Heart·Damage () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
@@ -366,7 +366,8 @@ ___
 ### Set·Stage () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
 #### void SetStage ( int StageOffset, int StageTypeOffset ) {: .copyable aria-label='Functions' }
-for SetStage/SetNextStage to have effect, call Init afterward
+
+This function changes the current floor, and it's stage. For the changes to fully apply, either use the `reseed` [console command](tutorials/DebugConsole.md#reseed), or [Game.StartStageTransition](Game.md#startstagetransition).
 
 StageOffset acts as the new "floor":
 
@@ -376,9 +377,9 @@ StageOffset acts as the new "floor":
 
 StageTypeOffset tells the game what "stage" to use, based on the listed IDs in [stages.xml](xml/stages.md), however, the default stage of the floor's ID will be added on top of this
 
-* StageOffset = 1 means the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
-* StageOffset = 2 means the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
-* StageOffset = 3 means the stage at ID 4(Caves' stage ID) + StageTypeOffset
+* StageOffset = 1 uses the stage at ID 1(Basement's stage ID) + StageTypeOffset, 
+* StageOffset = 2 uses the stage at ID 1(Same as StageOffset 1) + StageTypeOffset,
+* StageOffset = 3 uses the stage at ID 4(Caves' stage ID) + StageTypeOffset
 
 If you wish to directly use a stage ID, you can subtract the default stage for any given floor using a function like:
 ```lua


### PR DESCRIPTION
Corrected listed bug for Game:StartStageTransition(), and removed Transition Types, as they seemingly had no actual effect.
Explained the use of Level:SetStage(), replaced the original description from the official docs referencing a seemingly non-existant function, and made it and Level:SetNextStage() reference reseed and Game:StartStageTransition()