### PR TITLE
Update Entity.md

### DIFF
--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -781,7 +781,7 @@ ___
 
 This is the grid index with which the entity spawned upon room generation.
 
-Rerolled item pedestals, or entities spawned after the initnal room generation will have a value of -1
+Rerolled item pedestals, or entities spawned after the inital room generation will have a value of -1
 
 ___
 ### Splat·Color {: aria-label='Variables' }

--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -779,6 +779,10 @@ ___
 [ ](#){: .const .tooltip .badge } [ ](#){: .abrep .tooltip .badge }
 #### const int SpawnGridIndex  {: .copyable aria-label='Variables' }
 
+This is the grid index with which the entity spawned upon room generation.
+
+Rerolled item pedestals, or entities spawned after the initnal room generation will have a value of -1
+
 ___
 ### Splat·Color {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }


### PR DESCRIPTION
added description for SpawnGridIndex, and its effects

and specified that it is -1 for entities spawned after initial room generation.