### PR TITLE
Update BedSubType.md

### DIFF
--- a/docs/enums/BedSubType.md
+++ b/docs/enums/BedSubType.md
@@ -6,4 +6,4 @@ tags:
 |DLC|Value|Enumerator|Comment|
 |:--|:--|:--|:--|
 |[ ](#){: .rep .tooltip .badge }|0 |BED_ISAAC {: .copyable } |  |
-|[ ](#){: .rep .tooltip .badge }|1 |BED_MOM {: .copyable } |  |
+|[ ](#){: .rep .tooltip .badge }|1 |BED_MOM {: .copyable } | The subtype for Mom's bed is actually 10, making this enumerator useless. |


### PR DESCRIPTION
The sub type enum for mom's bed is completely incorrect, since the sub type is actually 10 and not 1. That's funny.