### PR TITLE
Document optional "Reset" boolean for Sprite.SetOverlayAnimation

### DIFF
--- a/docs/Sprite.md
+++ b/docs/Sprite.md
@@ -366,7 +366,11 @@ ___
 ___
 ### Set·Overlay·Animation () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean SetOverlayAnimation ( string AnimationName ) {: .copyable aria-label='Functions' }
+#### boolean SetOverlayAnimation ( string AnimationName, bool Reset = true ) {: .copyable aria-label='Functions' }
+
+Similar to the `Sprite.PlayOverlay` method, but does not start the animation.
+
+- **Reset** - as false will continue the animation from the current frame. This is a really good tool for familiars that alternate between different FloatDirection animations dynamically and other entities that follow similar behaviors.
 
 ___
 ### Set·Overlay·Frame () {: aria-label='Functions' }


### PR DESCRIPTION
It actually exists, same as the optional bool for Sprite.SetAnimation

Works in-game and you can see it in resources/scripts/main.lua if you need to double check.