### PR TITLE
Typo in ItemConfig functions

### DIFF
--- a/docs/ItemConfig.md
+++ b/docs/ItemConfig.md
@@ -7,7 +7,7 @@ tags:
 ???+ info
     You can get this class by using the following function:
 
-    * [Isaac:GetItemConfig()](Isaac.md#getitemconfig)
+    * [Isaac.GetItemConfig()](Isaac.md#getitemconfig)
 
     ???+ example "Example Code"
         `Isaac.GetItemConfig()`


### PR DESCRIPTION
The code before the example uses colon to access methods for `Isaac`, although methods for `Isaac` are accessed via dot.
