### PR TITLE
Fix weird link names in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,12 +15,12 @@ nav:
             - "": PLACEHOLDER.md
             - "": PLACEHOLDER.md
         - "Frequently used":
-            - "Isaac.": Isaac.md
+            - "Isaac": Isaac.md
             - "Entity": Entity.md
-            - "-- EntityPlayer": EntityPlayer.md
-            - "-- EntityNPC": EntityNPC.md
-            - "-- EntityEffect": EntityEffect.md
-            - "Game():": Game.md
+            - "EntityPlayer": EntityPlayer.md
+            - "EntityNPC": EntityNPC.md
+            - "EntityEffect": EntityEffect.md
+            - "Game": Game.md
             - "Room": Room.md
             - "Level": Level.md
             - "ModCallbacks": enums/ModCallbacks.md


### PR DESCRIPTION
Noticed this within the REPENTOGON docs and figured I'd push a PR for the regular docs too. No clue why or when these were changed to look like this, but this fixes it. You'll need to clear browser cache to see the changes.