### PR TITLE
Update EntityPartition.md

### DIFF
--- a/docs/enums/EntityPartition.md
+++ b/docs/enums/EntityPartition.md
@@ -15,4 +15,4 @@ tags:
 |[ ](#){: .abrep .tooltip .badge }|1 << 3 |ENEMY {: .copyable } |  |
 |[ ](#){: .abrep .tooltip .badge }|1 << 4 |PICKUP {: .copyable } |  |
 |[ ](#){: .abrep .tooltip .badge }|1 << 5 |PLAYER {: .copyable } |  |
-|[ ](#){: .abrep .tooltip .badge }|1 << 6 |EFFECT {: .copyable } | [](#){: .rep .tooltip .badge } **BUG:** This flag currently does not work! |
+|[ ](#){: .abrep .tooltip .badge }|1 << 6 |EFFECT {: .copyable } |  |


### PR DESCRIPTION
FindInRadius method with Partition set to EntityPartition.EFFECT counts effect entities, as long their EntityCollisionClass is set to anything than ENTCOLL_NONE. That's confirmed by spawning Tiny Bugs or initializing custom entity with EntityCollisionClass set to ENTCOLL_ALL.
![image](https://github.com/user-attachments/assets/395b36b6-f5d3-4164-97cf-fbe45bd85889)
