### PR TITLE
Made AddNullEffect params link to NullItemID enum

### DIFF
--- a/docs/TemporaryEffects.md
+++ b/docs/TemporaryEffects.md
@@ -47,7 +47,7 @@ Adds the CollectibleEffect associated with a given item. If the passed item's Co
 ___
 ### Add·Null·Effect () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void AddNullEffect ( [ItemConfigNullItemID](ItemConfig_Item.md) NullId, boolean AddCostume = true, int Count = 1 ) {: .copyable aria-label='Functions' }
+#### void AddNullEffect ( [NullItemID](enums/NullItemID.md) NullId, boolean AddCostume = true, int Count = 1 ) {: .copyable aria-label='Functions' }
 
 ___
 ### Add·Trinket·Effect () {: aria-label='Functions' }


### PR DESCRIPTION
The NullItemID enum is nowhere to be found on the page, so since AddNullEffect takes the NullItemID parameter I thought it would be useful to link to it there.