### PR TITLE
Fixed Enum Argument Documentation

### DIFF
--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -568,7 +568,7 @@ ___
 ___
 ### Take·Damage () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean TakeDamage ( float Damage, int Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
+#### boolean TakeDamage ( float Damage, [DamageFlag](./enums/DamageFlag.md) Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
 
 
 ???- note "Notes"

--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -568,7 +568,7 @@ ___
 ___
 ### Take·Damage () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean TakeDamage ( float Damage, [DamageFlag](./enums/DamageFlag.md) Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
+#### boolean TakeDamage ( float Damage, [DamageFlag](/enums/DamageFlag.md) Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
 
 
 ???- note "Notes"

--- a/docs/Entity.md
+++ b/docs/Entity.md
@@ -568,7 +568,7 @@ ___
 ___
 ### Take·Damage () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean TakeDamage ( float Damage, [DamageFlag](/enums/DamageFlag.md) Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
+#### boolean TakeDamage ( float Damage, [DamageFlag](enums/DamageFlag.md) Flags, [EntityRef](EntityRef.md) Source, int DamageCountdown ) {: .copyable aria-label='Functions' }
 
 
 ???- note "Notes"

--- a/docs/EntityEffect.md
+++ b/docs/EntityEffect.md
@@ -23,7 +23,7 @@ tags:
 ___
 ### Is·Player·Creep () {: aria-label='Functions' }
 [ ](#){: .static .tooltip .badge } [ ](#){: .abrep .tooltip .badge }
-#### static boolean IsPlayerCreep ( [EffectVariant](./enums/EffectVariant.md) Variant ) {: .copyable aria-label='Functions' }
+#### static boolean IsPlayerCreep ( [EffectVariant](/enums/EffectVariant.md) Variant ) {: .copyable aria-label='Functions' }
 
 ___
 ### Set·Damage·Source () {: aria-label='Functions' }

--- a/docs/EntityEffect.md
+++ b/docs/EntityEffect.md
@@ -23,7 +23,7 @@ tags:
 ___
 ### Is·Player·Creep () {: aria-label='Functions' }
 [ ](#){: .static .tooltip .badge } [ ](#){: .abrep .tooltip .badge }
-#### static boolean IsPlayerCreep ( [EffectVariant](/enums/EffectVariant.md) Variant ) {: .copyable aria-label='Functions' }
+#### static boolean IsPlayerCreep ( [EffectVariant](enums/EffectVariant.md) Variant ) {: .copyable aria-label='Functions' }
 
 ___
 ### Set·Damage·Source () {: aria-label='Functions' }

--- a/docs/EntityEffect.md
+++ b/docs/EntityEffect.md
@@ -23,7 +23,7 @@ tags:
 ___
 ### Is·Player·Creep () {: aria-label='Functions' }
 [ ](#){: .static .tooltip .badge } [ ](#){: .abrep .tooltip .badge }
-#### static boolean IsPlayerCreep ( int Variant ) {: .copyable aria-label='Functions' }
+#### static boolean IsPlayerCreep ( [EffectVariant](./enums/EffectVariant.md) Variant ) {: .copyable aria-label='Functions' }
 
 ___
 ### Set·Damage·Source () {: aria-label='Functions' }

--- a/docs/EntityNPC.md
+++ b/docs/EntityNPC.md
@@ -72,11 +72,9 @@ ___
 ___
 ### Get·Champion·Color·Idx () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetChampionColorIdx ( ) {: .copyable aria-label='Functions' }
+#### [ChampionColorIdx](ChampionColor) GetChampionColorIdx ( ) {: .copyable aria-label='Functions' }
 
-
-???- note "Notes"
-    A list of Champion colors can be found here : [ChampionColorIdx](enums/ChampionColor.md)
+Returns the NPC's champion color index. Returns -1 if the NPC is not a champion.
 ___
 ### Get·Player·Target () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }

--- a/docs/EntityNPC.md
+++ b/docs/EntityNPC.md
@@ -72,7 +72,7 @@ ___
 ___
 ### Get·Champion·Color·Idx () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### [ChampionColorIdx](ChampionColor) GetChampionColorIdx ( ) {: .copyable aria-label='Functions' }
+#### [ChampionColorIdx](enums/ChampionColor.md) GetChampionColorIdx ( ) {: .copyable aria-label='Functions' }
 
 Returns the NPC's champion color index. Returns -1 if the NPC is not a champion.
 ___

--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -588,7 +588,7 @@ Changing the player Type into Jacob will also spawn Esau.
 ___
 ### Check·Familiar () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void CheckFamiliar ( int [FamiliarVariant](enums/FamiliarVariant.md) FamiliarVariant, int TargetCount, [RNG](RNG.md) rng, [ItemConfigItem](ItemConfig_Item.md) SourceItemConfigItem = nil, int FamiliarSubType = -1 ) {: .copyable aria-label='Functions' }
+#### void CheckFamiliar ( [FamiliarVariant](enums/FamiliarVariant.md) FamiliarVariant, int TargetCount, [RNG](RNG.md) rng, [ItemConfigItem](ItemConfig_Item.md) SourceItemConfigItem = nil, int FamiliarSubType = -1 ) {: .copyable aria-label='Functions' }
 
 Call this method to spawn the appropriate amount of familiars associated with a custom collectible.
 

--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -588,7 +588,7 @@ Changing the player Type into Jacob will also spawn Esau.
 ___
 ### Check·Familiar () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void CheckFamiliar ( int FamiliarVariant, int TargetCount, [RNG](RNG.md) rng, [ItemConfigItem](ItemConfig_Item.md) SourceItemConfigItem = nil, int FamiliarSubType = -1 ) {: .copyable aria-label='Functions' }
+#### void CheckFamiliar ( int [FamiliarVariant](enums/FamiliarVariant.md) FamiliarVariant, int TargetCount, [RNG](RNG.md) rng, [ItemConfigItem](ItemConfig_Item.md) SourceItemConfigItem = nil, int FamiliarSubType = -1 ) {: .copyable aria-label='Functions' }
 
 Call this method to spawn the appropriate amount of familiars associated with a custom collectible.
 
@@ -700,6 +700,19 @@ ___
 ### Fire·Knife () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
 #### [EntityKnife](EntityKnife.md) FireKnife ( [Entity](Entity.md) Parent, float RotationOffset = 0, boolean CantOverwrite = false, int SubType = 0, int Variant = 0 ) {: .copyable aria-label='Functions' }
+
+???- note "Knife Variants"
+    ```lua
+    0: Mom's Knife
+    1: Bone Club
+    2: Bone Scythe
+    3: Berserk Club
+    4: Bag of Crafting
+    5: Sumptorium
+    9: Notched Axe
+    10: Spirit Sword
+    11: Tech Sword
+    ```
 
 ___
 ### Fire·Tear () {: aria-label='Functions' }

--- a/docs/EntityProjectile.md
+++ b/docs/EntityProjectile.md
@@ -18,7 +18,7 @@ tags:
 ## Functions
 ### Add·Change·Flags () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void AddChangeFlags ( int Flags ) {: .copyable aria-label='Functions' }
+#### void AddChangeFlags ( [ProjectileFlags](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 See [ChangeFlags](#changeflags).
 ___
@@ -39,7 +39,7 @@ ___
 ___
 ### Add·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void AddProjectileFlags ( int Flags ) {: .copyable aria-label='Functions' }
+#### void AddProjectileFlags ( [ProjectileFlags](./enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 You can change the attributes of the projectile by adding one or more [`ProjectileFlag`](enums/ProjectileFlags.md).
 
@@ -51,12 +51,12 @@ ___
 ___
 ### Clear·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void ClearProjectileFlags ( int Flags ) {: .copyable aria-label='Functions' }
+#### void ClearProjectileFlags ( [`ProjectileFlags`](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 ___
 ### Has·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### boolean HasProjectileFlags ( int Flags ) {: .copyable aria-label='Functions' }
+#### boolean HasProjectileFlags ( [`ProjectileFlags`](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 ___
 ## Variables
@@ -67,7 +67,7 @@ ___
 ___
 ### Change·Flags {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }
-#### int ChangeFlags  {: .copyable aria-label='Variables' }
+#### [ProjectileFlags](enums/ProjectileFlags.md) ChangeFlags  {: .copyable aria-label='Variables' }
 
 Uses [ProjectileFlags](enums/ProjectileFlags.md) to define the projectile attributes after the "Changed" state was activated.
 The [ProjectileFlag](enums/ProjectileFlags.md).CHANGE_FLAGS_AFTER_TIMEOUT needs to be set to allow for this change to apply!

--- a/docs/EntityProjectile.md
+++ b/docs/EntityProjectile.md
@@ -51,12 +51,12 @@ ___
 ___
 ### Clear·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void ClearProjectileFlags ( [`ProjectileFlags`](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
+#### void ClearProjectileFlags ( [ProjectileFlags](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 ___
 ### Has·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### boolean HasProjectileFlags ( [`ProjectileFlags`](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
+#### boolean HasProjectileFlags ( [ProjectileFlags](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 ___
 ## Variables

--- a/docs/EntityProjectile.md
+++ b/docs/EntityProjectile.md
@@ -39,7 +39,7 @@ ___
 ___
 ### Add·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void AddProjectileFlags ( [ProjectileFlags](/enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
+#### void AddProjectileFlags ( [ProjectileFlags](enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 You can change the attributes of the projectile by adding one or more [`ProjectileFlag`](enums/ProjectileFlags.md).
 

--- a/docs/EntityProjectile.md
+++ b/docs/EntityProjectile.md
@@ -39,7 +39,7 @@ ___
 ___
 ### Add·Projectile·Flags () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void AddProjectileFlags ( [ProjectileFlags](./enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
+#### void AddProjectileFlags ( [ProjectileFlags](/enums/ProjectileFlags.md) Flags ) {: .copyable aria-label='Functions' }
 
 You can change the attributes of the projectile by adding one or more [`ProjectileFlag`](enums/ProjectileFlags.md).
 

--- a/docs/EntityTear.md
+++ b/docs/EntityTear.md
@@ -24,7 +24,7 @@ tags:
 ___
 ### Change·Variant () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### void ChangeVariant ( int NewVariant ) {: .copyable aria-label='Functions' }
+#### void ChangeVariant ( [TearVariant](enums/TearVariant.md) NewVariant ) {: .copyable aria-label='Functions' }
 
 ___
 ### Clear·Tear·Flags () {: aria-label='Functions' }

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -70,7 +70,7 @@ Returns, if an action-button is pressed or not. An Action-button is any button t
 ___
 ### Is·Action·Triggered () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean IsActionTriggered ( [ButtonAction](enums/ButtonAction.md), int controllerId ) {: .copyable aria-label='Functions' }
+#### boolean IsActionTriggered ( [ButtonAction](enums/ButtonAction.md) action, int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns, if an action-button was pressed some time before or not. An Action-button is any button that got a default function assigned to it. This functions will only return true, if the button was pressed down. It will no longer return true, after you called this function and try to call it in the next update cycle (for example in the next render cycle).
 

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -18,7 +18,7 @@ tags:
 ## Functions
 ### Get·Action·Value () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### float GetActionValue ( int action, int controllerId ) {: .copyable aria-label='Functions' }
+#### float GetActionValue ( [ButtonAction](enums/ButtonAction.md) action, int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns the current strength in which a button was pressed. This is 0 OR 1 with a keyboard. With a controller, this can be used to get the strength in which you have moved the analog stick in a direction.
 
@@ -26,13 +26,12 @@ Returns the current strength in which a button was pressed. This is 0 OR 1 with 
     This code prints the current "strength" in which the analog stick was moved to the left.
     ```lua
     print(Input.GetActionValue(ButtonAction.ACTION_LEFT, 1))
-
     ```
 
 ___
 ### Get·Button·Value () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### float GetButtonValue ( int button, int controllerId ) {: .copyable aria-label='Functions' }
+#### float GetButtonValue ( [Keyboard](enums/Keyboard.md) button, int controllerId ) {: .copyable aria-label='Functions' }
 
 Use "GetActionValue" instead of this function.
 ___
@@ -54,7 +53,7 @@ Returns the current mouse position in game coordinates (true) or render coordina
 ___
 ### Is·Action·Pressed () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean IsActionPressed ( int action, int controllerId ) {: .copyable aria-label='Functions' }
+#### boolean IsActionPressed ( [ButtonAction](enums/ButtonAction.md) action, int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns, if an action-button is pressed or not. An Action-button is any button that got a default function assigned to it. This function will return true, as long the button is held down.
 
@@ -71,7 +70,7 @@ Returns, if an action-button is pressed or not. An Action-button is any button t
 ___
 ### Is·Action·Triggered () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean IsActionTriggered ( int action, int controllerId ) {: .copyable aria-label='Functions' }
+#### boolean IsActionTriggered ( [ButtonAction](enums/ButtonAction.md), int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns, if an action-button was pressed some time before or not. An Action-button is any button that got a default function assigned to it. This functions will only return true, if the button was pressed down. It will no longer return true, after you called this function and try to call it in the next update cycle (for example in the next render cycle).
 
@@ -83,12 +82,11 @@ Returns, if an action-button was pressed some time before or not. An Action-butt
     if Input.IsActionTriggered(ButtonAction.ACTION_BOMB, 0)  then
         print("bomb Button pressed")
     end
-
     ```
 ___
 ### Is·Button·Pressed () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean IsButtonPressed ( int button, int controllerId ) {: .copyable aria-label='Functions' }
+#### boolean IsButtonPressed ( [Keyboard](enums/Keyboard.md) button, int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns, if a button is pressed or not. This function will return true, as long the button is held down.
 
@@ -100,12 +98,11 @@ Returns, if a button is pressed or not. This function will return true, as long 
     if Input.IsButtonPressed(Keyboard.KEY_ENTER, 0)  then
         print("Enter Button pressed.")
     end
-
     ```
 ___
 ### Is·Button·Triggered () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### boolean IsButtonTriggered ( int button, int controllerId ) {: .copyable aria-label='Functions' }
+#### boolean IsButtonTriggered ( [Keyboard](enums/Keyboard.md) button, int controllerId ) {: .copyable aria-label='Functions' }
 
 Returns, if a button was pressed some time before or not. This functions will only return true, if the button was pressed down. It will no longer return true, after you called this function and try to call it in the next update cycle (for example in the next render cycle).
 
@@ -117,7 +114,6 @@ Returns, if a button was pressed some time before or not. This functions will on
     if Input.IsButtonTriggered(Keyboard.KEY_ENTER, 0)  then
         print("Enter Button was pressed.")
     end
-
     ```
 ___
 ### Is·Mouse·Btn·Pressed () {: aria-label='Functions' }

--- a/docs/Isaac.md
+++ b/docs/Isaac.md
@@ -26,7 +26,7 @@ It is recommended to use the [AddCallback](ModReference.md#addcallback) function
 ___
 ### Add·Pill·Effect·To·Pool () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int AddPillEffectToPool ( int pillEffect ) {: .copyable aria-label='Functions' }
+#### [PillColor](enums/PillColor.md) AddPillEffectToPool ( [PillEffect](enums/PillEffect.md) pillEffect ) {: .copyable aria-label='Functions' }
 Returns the [PillColor](enums/PillColor.md) of the added pill.
 
 ___
@@ -136,7 +136,7 @@ If `createIfMissing` is `false` or `nil` and there are no callbacks added under 
 ___
 ### Get·Card·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetCardIdByName ( string cardHudName ) {: .copyable aria-label='Functions' }
+#### [Card](enums/Card.md) GetCardIdByName ( string cardHudName ) {: .copyable aria-label='Functions' }
 Returns the [CardID](enums/Card.md) based on the "hud"-attribute defined in the "pocketitems.xml" file. Returns `-1` if no card with that "hud" attribute value could be found.
 
 ???+ warning "Warning"
@@ -159,12 +159,12 @@ Returns the [CardID](enums/Card.md) based on the "hud"-attribute defined in the 
 ___
 ### Get·Challenge () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetChallenge ( ) {: .copyable aria-label='Functions' }
+#### [Challenge](enums/Challenge.md) GetChallenge ( ) {: .copyable aria-label='Functions' }
 Returns the ID of a challenge the player is currently in. Returns 0 if the player is not playing any challenge.
 ___
 ### Get·Challenge·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetChallengeIdByName ( string challengeName ) {: .copyable aria-label='Functions' }
+#### [Challenge](enums/Challenge.md) GetChallengeIdByName ( string challengeName ) {: .copyable aria-label='Functions' }
 
 Returns the ChallengeID of a challenge based on its name. (File: challenges.xml) Returns `-1` if no challenge with that name could be found (Case sensitive).
 
@@ -192,7 +192,7 @@ Returns the CostumeID of a costume based on its file path. (File: costumes2.xml)
 ___
 ### Get·Curse·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetCurseIdByName ( string curseName ) {: .copyable aria-label='Functions' }
+#### [LevelCurse](enums/LevelCurse.md) GetCurseIdByName ( string curseName ) {: .copyable aria-label='Functions' }
 
 Returns the CurseID of a curse based on its name. (File: curses.xml) Returns `-1` if no curse with that name could be found.
 
@@ -206,7 +206,7 @@ Returns the CurseID of a curse based on its name. (File: curses.xml) Returns `-1
 ___
 ### Get·Entity·Type·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetEntityTypeByName ( string entityName ) {: .copyable aria-label='Functions' }
+#### [EntityType](enums/EntityType.md) GetEntityTypeByName ( string entityName ) {: .copyable aria-label='Functions' }
 
 Returns the EntityType of an entity based on its name. (File: entities2.xml) Returns `0` if no entity with that name could be found.
 
@@ -262,7 +262,7 @@ This is the only way to access the `ItemConfig` object.
 ___
 ### Get·Item·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetItemIdByName ( string itemName ) {: .copyable aria-label='Functions' }
+#### [CollectibleType](enums/CollectibleType.md) GetItemIdByName ( string itemName ) {: .copyable aria-label='Functions' }
 
 Returns the ItemID of a Collectible. (File: items.xml) Returns `-1` if no item with that name could be found.
 
@@ -278,7 +278,7 @@ Returns the ItemID of a Collectible. (File: items.xml) Returns `-1` if no item w
 ___
 ### Get·Music·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetMusicIdByName ( string musicName ) {: .copyable aria-label='Functions' }
+#### [Music](enums/Music.md) GetMusicIdByName ( string musicName ) {: .copyable aria-label='Functions' }
 
 Returns the MusicID of a music track. (File: music.xml) Returns `-1` if no music with that name could be found.
 
@@ -294,7 +294,7 @@ Returns the MusicID of a music track. (File: music.xml) Returns `-1` if no music
 ___
 ### Get·Pill·Effect·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetPillEffectByName ( string pillEffect ) {: .copyable aria-label='Functions' }
+#### [PillEffect](enums/PillEffect.md) GetPillEffectByName ( string pillEffect ) {: .copyable aria-label='Functions' }
 
 Returns the PillEffectID based on its name. (File: pocketitems.xml) Returns `-1` if no pill with that name could be found.
 
@@ -412,9 +412,9 @@ ___
 ___
 ### Get·Sound·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetSoundIdByName ( string soundName ) {: .copyable aria-label='Functions' }
+#### [SoundEffect](enums/SoundEffect.md) GetSoundIdByName ( string soundName ) {: .copyable aria-label='Functions' }
 
-Returns the SoundEffectID of a sound based on its name. (File: sounds.xml) Returns `-1` if no sound with that name could be found.
+Returns the [SoundEffect](enums/SoundEffect.md) of a sound based on its name. (File: sounds.xml) Returns `-1` if no sound with that name could be found.
 
 ???- example "Example Code"
     This code gets the SoundEffectID of a sound named "Custom Sound Effect"
@@ -445,7 +445,7 @@ For example, you could use this to implement an on-screen speedrunning timer bas
 ___
 ### Get·Trinket·Id·By·Name () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetTrinketIdByName ( string trinketName ) {: .copyable aria-label='Functions' }
+#### [TrinketType](enums/TrinketType.md) GetTrinketIdByName ( string trinketName ) {: .copyable aria-label='Functions' }
 
 Returns the TrinketType of a trinket based on its name. (File: items.xml) Returns `-1` if no trinket with that name could be found.
 
@@ -609,7 +609,7 @@ ___
 
 ### Spawn () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### [Entity](Entity.md) Spawn ( int entityType, int entityVariant, int entitySubtype, [Vector](Vector.md) position, [Vector](Vector.md) velocity, [Entity](Entity.md) Spawner ) {: .copyable aria-label='Functions' }
+#### [Entity](Entity.md) Spawn ( [EntityType](enums/EntityType.md) entityType, int entityVariant, int entitySubtype, [Vector](Vector.md) position, [Vector](Vector.md) velocity, [Entity](Entity.md) Spawner ) {: .copyable aria-label='Functions' }
 
 Spawns the defined entity at the given location. If the position is not free, it spawns it in the nearest free position.
 

--- a/docs/Level.md
+++ b/docs/Level.md
@@ -95,7 +95,7 @@ Gets the modifier value of the chance for this floor's deal to be an Angel room.
 
 ???+ info
     If this value is above `0.0`, deals can become Angel rooms even if a player has already taken a Devil deal item. If the chance is positive and a deal room has not spawned yet, the deal is guaranteed to be an Angel room.
-    
+
     Under normal circumstances, setting this value to below `0.0` will _not_ reduce the chance for an Angel room, as values below `0.0` are usually ignored. A negative value will only affect Angel room chance if the player has an item that enables visiting Angel rooms even if a Devil deal has already been taken, such as Book of Virtues or Act of Contrition.
 
 ___
@@ -139,7 +139,7 @@ ___
 ___
 ### Get·Curses () {: aria-label='Functions' }
 [ ](#){: .abrep .tooltip .badge }
-#### int GetCurses ( ) {: .copyable aria-label='Functions' }
+#### [LevelCurse](enums/LevelCurse.md) GetCurses ( ) {: .copyable aria-label='Functions' }
 
 ___
 ### Get·Devil·Angel·Room·RNG () {: aria-label='Functions' }
@@ -316,7 +316,7 @@ Attempts to create a red room door in the given room at the given door slot. Ret
 
 ???- note "Notes"
 	This function can be used to create rooms not connected to any other room. For example, calling `MakeRedRoomDoor(2, DoorSlot.DOOR_LEFT0)` will create a room where `Slot` of `CurrentRoomIdx` would connect to, in this case grid index 1.
-	
+
 	Rooms can also be forced to be created by setting [Challenge](Game.md#challenge) to Red Redemption (`Challenge.CHALLENGE_RED_REDEMPTION`). Note that creating a room connected to an otherwise invalid slot will cause the door to lead to an Error room!
 ___
 ### Query·Room·Type·Index () {: aria-label='Functions' }
@@ -367,13 +367,13 @@ This function changes the current floor, and it's stage. For the changes to full
 
 StageOffset acts as the new "floor":
 
-* 1 would be equally difficult to Basement I, 
+* 1 would be equally difficult to Basement I,
 * 2 would be equally difficult to Basement II,
 * 3 would be equally difficult to Caves I
 
 StageTypeOffset tells the game what "stage" to use, based on the listed IDs in [stages.xml](xml/stages.md), however, the default stage of the floor's ID will be added on top of this
 
-* StageOffset = 1 uses the stage at ID: StageTypeOffset + 1(Basement's stage ID), 
+* StageOffset = 1 uses the stage at ID: StageTypeOffset + 1(Basement's stage ID),
 * StageOffset = 2 uses the stage at ID: StageTypeOffset + 1(Same as StageOffset 1),
 * StageOffset = 3 uses the stage at ID: StageTypeOffset + 4(Caves' stage ID)
 

--- a/docs/ProjectileParams.md
+++ b/docs/ProjectileParams.md
@@ -34,7 +34,7 @@ ___
 ___
 ### Change·Flags {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }
-#### int ChangeFlags  {: .copyable aria-label='Variables' }
+#### [ProjectileFlags](enums/ProjectileFlags.md) ChangeFlags  {: .copyable aria-label='Variables' }
 
 Uses [ProjectileFlags](enums/ProjectileFlags.md) to define the projectile attributes after the "Changed" state was activated.
 The [ProjectileFlag](enums/ProjectileFlags.md).CHANGE_FLAGS_AFTER_TIMEOUT needs to be set to allow for this change to apply!

--- a/docs/RoomDescriptor.md
+++ b/docs/RoomDescriptor.md
@@ -97,7 +97,7 @@ Indicates what is visible on the minimap.
 ___
 ### Flags {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }
-#### int Flags  {: .copyable aria-label='Variables' }
+#### [RoomDescriptor](./enums/RoomDescriptor.md) Flags  {: .copyable aria-label='Variables' }
 The RoomDescriptor flags for the room.
 ___
 ### Grid·Index {: aria-label='Variables' }

--- a/docs/RoomDescriptor.md
+++ b/docs/RoomDescriptor.md
@@ -97,7 +97,7 @@ Indicates what is visible on the minimap.
 ___
 ### Flags {: aria-label='Variables' }
 [ ](#){: .abrep .tooltip .badge }
-#### [RoomDescriptor](./enums/RoomDescriptor.md) Flags  {: .copyable aria-label='Variables' }
+#### [RoomDescriptor](enums/RoomDescriptor.md) Flags  {: .copyable aria-label='Variables' }
 The RoomDescriptor flags for the room.
 ___
 ### Grid·Index {: aria-label='Variables' }

--- a/docs/TemporaryEffects.md
+++ b/docs/TemporaryEffects.md
@@ -47,7 +47,7 @@ Adds the CollectibleEffect associated with a given item. If the passed item's Co
 ___
 ### Add·Null·Effect () {: aria-label='Functions' }
 [ ](#){: .rep .tooltip .badge }
-#### void AddNullEffect ( [ItemConfigNullItemID](ItemConfig_Item.md) NullId, boolean AddCostume = true, int Count = 1 ) {: .copyable aria-label='Functions' }
+#### void AddNullEffect ( [NullItemID](enums/NullItemID.md) NullId, boolean AddCostume = true, int Count = 1 ) {: .copyable aria-label='Functions' }
 
 ___
 ### Add·Trinket·Effect () {: aria-label='Functions' }


### PR DESCRIPTION
There is an inconsistency where methods that return an enum value or requires one as an argument is either documented as such or it's just simply an `int`. This commit improves clarity by properly referencing the enums.