### PR TITLE
Update DebugConsole.md (Debug 4)

### DIFF
--- a/docs/tutorials/DebugConsole.md
+++ b/docs/tutorials/DebugConsole.md
@@ -100,7 +100,7 @@ Various cheats that are useful for testing. Some of the ones not listed here are
 
 **debug 3** Complete invincibility
 
-**debug 4** +40 damage. Good with Soy Milk.
+**debug 4** +40 damage. Good with Soy Milk. (In Repentance/Repentance+, also causes all spawned trinkets to be golden)
 
 **debug 5** Displays text at the bottom of the screen about the current room
 


### PR DESCRIPTION
Having the "debug 4" console command active causes all spawned trinkets (room clear, chests, spawning via console, etc.) to be golden.

Noticed while testing a WIP mod. Then disabled all mods, restarted the game, and tested again with the same results.

Downgraded from Repentance+ to Repentance, and the same still happened.