### PR TITLE
MaxFireDelay, README, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /site
 /scripts/results/*
+/bin
+/lib
+lib64
+pyvenv.cfg

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This project aims to make the Binding of Isaac modding documentation better by p
 - **Last visited pages** - history
 - **Dark mode**
 - **Quick Edit** - Button
-- **Smart-Copy** Feature to quickly copy 
+- **Smart-Copy** Feature to quickly copy
 - Automatic deployment & updates (using Github actions)
 - and a lot more!
 
 ## Technology used
 
-- [MkDocs](https://www.mkdocs.org/) as the static site generator 
+- [MkDocs](https://www.mkdocs.org/) as the static site generator
 - [MKDocs Material Theme](https://squidfunk.github.io/mkdocs-material/)
 - [mark.js](https://markjs.io/) for better search highlighting
 - Python 3.x + Beautiful Soup for conversion tools
@@ -29,7 +29,9 @@ This project aims to make the Binding of Isaac modding documentation better by p
 
 1. Clone the repository.
 1. Install a current version of Python 3.x.
-1. `pip install -r requirements.txt`
 1. `cd IsaacDocs`
+1. `python3 -m venv .`
+1. `. ./bin/activate`s
+1. `pip install -r requirements.txt`
 1. Use `mkdocs serve` to create a locally hosted version of the page available at: `http://127.0.0.1:8000/`
 1. Alternatively, use `mkdocs build` to build a static version of the page.

--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -1989,7 +1989,7 @@ Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How long must
     end
 
     function set_fire_rate(player, fire_rate)
-        fire_rate = math.min(fire_rate, FIRE_RATE_CAP) -- Apply fire rate cap.
+        local fire_rate = math.min(fire_rate, FIRE_RATE_CAP) -- Apply fire rate cap.
         player.MaxFireDelay = 30 / fire_rate - 1
     end
 

--- a/docs/EntityPlayer.md
+++ b/docs/EntityPlayer.md
@@ -1969,12 +1969,37 @@ ___
 Player stat - Only change this in a callback to MC_EVALUATE_CACHE.  **This is equal to the Luck Stat.**  Better luck generally means better random events.
 ___
 ### Max·Fire·Delay {: aria-label='Variables' }
-[ ](#){: .alldlc .tooltip .badge }
+[ ](#){: .abp .tooltip .badge }
+#### int MaxFireDelay  {: .copyable aria-label='Variables' }
+[ ](#){: .reporplus .tooltip .badge }
 #### float MaxFireDelay  {: .copyable aria-label='Variables' }
-Player stat - Only change this in a callback to MC_EVALUATE_CACHE.  **This is equal to the Tears Stat.**  How long between each tear can spawn?
+Player stat - Only change this in a callback to MC_EVALUATE_CACHE. How long must the player wait between each firing each tear?
 
-???- note "Version Difference"
-	In the Afterbirth+ version of the modding api, this variable is an integer
+???+ info "Info"
+    This stat is equal to `30 / tears stat - 1`.
+
+???- example "Example Code"
+    This code converts between max fire delay and tears stat and increases fire rate by 1. Note that this applies after the soft tear cap and tear multipliers such as the ones from Polyphemus and Soy Milk.
+
+    ```lua
+    FIRE_RATE_CAP = 120
+
+    function get_fire_rate(player)
+	    return 30 / (player.MaxFireDelay + 1)
+    end
+
+    function set_fire_rate(player, fire_rate)
+        fire_rate = math.min(fire_rate, FIRE_RATE_CAP) -- Apply fire rate cap.
+        player.MaxFireDelay = 30 / fire_rate - 1
+    end
+
+    function mod:OnEvaluateFireRate(player, flag)
+        local old_fire_rate = get_fire_rate(player)
+        set_fire_rate(player, old_fire_rate + 1)
+    end
+
+    mod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, mod.OnEvaluateFireRate, CacheFlag.CACHE_FIREDELAY)
+    ```
 
 ___
 ### Move·Speed {: aria-label='Variables' }


### PR DESCRIPTION
* Reworked MaxFireDelay documentation.
  * Removed the text saying it's equivalent to the tears stat.
  * Added functions to the example code for converting between max fire delay and fire rate and increasing the player's fire rate.
  * `int` datatype for this property is now indicated as an AB+ signature instead of a collapsible note at the bottom.
* Reworked local version instructions.
  * Fixed order of `pip` and `cd` and added instructions for setting it up as a virtual environment.