### PR TITLE
Change fandom/gamepedia wiki links to wiki.gg

### DIFF
--- a/docs/EntityNPC.md
+++ b/docs/EntityNPC.md
@@ -115,7 +115,7 @@ ___
 #### boolean Morph ( [EntityType](enums/EntityType.md) type, int Variant, int SubType, int ChampionColorIdx ) {: .copyable aria-label='Functions' }
 
 Morph the current entity into another one. [ChampionColorIdx](https://bindingofisaacrebirth.wiki.gg/wiki/Champions) can be used to turn the entity into a champion. Use `:::lua -1` in order to not add a champion color.
-A list of Champion colors can be found here : [ChampionColorIdx](https://bindingofisaacrebirth.gamepedia.com/Monsters#Champions)
+A list of Champion colors can be found here : [ChampionColorIdx](https://bindingofisaacrebirth.wiki.gg/wiki/Champions)
 
 ???+ bug
     This function can not turn a champion NPC into a regular NPC! for that, use the following code:

--- a/docs/EntityNPC.md
+++ b/docs/EntityNPC.md
@@ -114,7 +114,7 @@ ___
 [ ](#){: .alldlc .tooltip .badge }
 #### boolean Morph ( [EntityType](enums/EntityType.md) type, int Variant, int SubType, int ChampionColorIdx ) {: .copyable aria-label='Functions' }
 
-Morph the current entity into another one. [ChampionColorIdx](https://bindingofisaacrebirth.gamepedia.com/Monsters#Champions) can be used to turn the entity into a champion. Use `:::lua -1` in order to not add a champion color.
+Morph the current entity into another one. [ChampionColorIdx](https://bindingofisaacrebirth.wiki.gg/wiki/Champions) can be used to turn the entity into a champion. Use `:::lua -1` in order to not add a champion color.
 A list of Champion colors can be found here : [ChampionColorIdx](https://bindingofisaacrebirth.gamepedia.com/Monsters#Champions)
 
 ???+ bug

--- a/docs/Room.md
+++ b/docs/Room.md
@@ -241,7 +241,7 @@ This gives the total devil deal percentage for the floor. It doesn't split it in
         end
       end
 
-      -- https://bindingofisaacrebirth.fandom.com/wiki/Angel_Room#Angel_Room_Generation_Chance
+      -- https://bindingofisaacrebirth.wiki.gg/wiki/Angel_Room#Angel_Room_Generation_Chance
       if devilRoomChance == 0.5 then
         if anyPlayerHasTrinket(TrinketType.TRINKET_ROSARY_BEAD) then
           devilRoomChance = devilRoomChance * (1.0 - 0.5)

--- a/docs/Seeds.md
+++ b/docs/Seeds.md
@@ -20,7 +20,7 @@ tags:
 [ ](#){: .alldlc .tooltip .badge }
 #### void AddSeedEffect ( [SeedEffect](enums/SeedEffect.md) Value ) {: .copyable aria-label='Functions' }
 
-A "seed effect" is equivalent to an [easter egg](https://bindingofisaacrebirth.fandom.com/wiki/Seeds#Special_Seeds).
+A "seed effect" is equivalent to an [easter egg](https://bindingofisaacrebirth.wiki.gg/wiki/Seeds#Special_Seeds).
 
 ___
 ### Can·Add·Seed·Effect () {: aria-label='Functions' }

--- a/docs/faq/GettingStarted.md
+++ b/docs/faq/GettingStarted.md
@@ -71,9 +71,9 @@ The options.ini file is located here:
     
 
 
-To open the console, press the **grave/tilde (~)** key while in a run. If you are on a non-English keyboard, see the [wiki page on the debug console](https://bindingofisaacrebirth.gamepedia.com/Debug_Console) for more information.
+To open the console, press the **grave/tilde (~)** key while in a run. If you are on a non-English keyboard, see the [wiki page on the debug console](https://bindingofisaacrebirth.wiki.gg/Debug_Console) for more information.
 
-The wiki also has a [list of every console command](https://bindingofisaacrebirth.gamepedia.com/Debug_Console).
+The wiki also has a [list of every console command](https://bindingofisaacrebirth.wiki.gg/wiki/Debug_Console#Listed_Commands).
 
 ## Where is the directory/folder for mods located? {: .subHeader}
 

--- a/docs/faq/interactive_FAQ.md
+++ b/docs/faq/interactive_FAQ.md
@@ -48,7 +48,7 @@ INTERACTIVE_questions = {
       ]
     },
     "VERSION_MISMATCH" : {
-      text: 'Some issues might occur, because you dont have the most recent version of the game installed, making some mods not work correctly anymore. You can look up the installed version of the game inside the "log.txt" file (See: Blue arrow on screenshot), found inside this folder:<br>C:\\Users\\[YourUsername]\\Documents\\My Games\\Binding of Isaac Repentance\\<br>You can look up the most recent version number of the game in the Wiki <a href="https://bindingofisaacrebirth.fandom.com/wiki/Version_History">https://bindingofisaacrebirth.fandom.com/wiki/Version_History</a><br>If your version number is not the same as the most recent one, please update your game and try to use the mod again.',
+      text: 'Some issues might occur, because you dont have the most recent version of the game installed, making some mods not work correctly anymore. You can look up the installed version of the game inside the "log.txt" file (See: Blue arrow on screenshot), found inside this folder:<br>C:\\Users\\[YourUsername]\\Documents\\My Games\\Binding of Isaac Repentance\\<br>You can look up the most recent version number of the game in the Wiki <a href="https://bindingofisaacrebirth.wiki.gg/wiki/Version_History">https://bindingofisaacrebirth.wiki.gg/wiki/Version_History</a><br>If your version number is not the same as the most recent one, please update your game and try to use the mod again.',
       image: "../images/faq/logfile_location.png",
     },
     "DLC_MISSING" : {

--- a/docs/tutorials/Using-Additional-Lua-Files.md
+++ b/docs/tutorials/Using-Additional-Lua-Files.md
@@ -79,7 +79,7 @@ local MOD_NAME = "MyMod" -- Cannot have spaces, since it represents a path.
 
 -- Players can boot the game with an launch option called "--luadebug", which will enable additional
 -- functionality that is considered to be unsafe. For more information about this flag, see the
--- wiki: https://bindingofisaacrebirth.fandom.com/wiki/Launch_Options
+-- wiki: https://bindingofisaacrebirth.wiki.gg/wiki/Launch_Options
 --
 -- When this flag is enabled, the global environment will be slightly different. The differences are
 -- documented here: https://wofsauge.github.io/IsaacDocs/rep/Globals.html


### PR DESCRIPTION
This changes `fandom.com` and `gamepedia.com` to equivalent wiki.gg links instead. Fandom is not reliable anymore due to the amount of griefing Fandom permits on their platform.